### PR TITLE
Implement new context type: HTTP header

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2016-01-06  Michael Schams  <typo3@2016.schams.net>
 
 	* Implement new context type: HTTP header
+	* Update documentation
 
 2015-07-10  Christian Weiske  <christian.weiske@netresearch.de>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-01-06  Michael Schams  <typo3@2016.schams.net>
+
+	* Implement new context type: HTTP header
+
 2015-07-10  Christian Weiske  <christian.weiske@netresearch.de>
 
 	* Fix #65964: Keep context configuration when copying content

--- a/Classes/Context/Type/HttpHeader.php
+++ b/Classes/Context/Type/HttpHeader.php
@@ -1,0 +1,82 @@
+<?php
+/***************************************************************
+*  Copyright notice
+*
+*  (c) 2016 Netresearch GmbH & Co. KG <typo3.org@netresearch.de>
+*  All rights reserved
+*
+*  This script is part of the TYPO3 project. The TYPO3 project is
+*  free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  The GNU General Public License can be found at
+*  http://www.gnu.org/copyleft/gpl.html.
+*
+*  This script is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  This copyright notice MUST APPEAR in all copies of the script!
+***************************************************************/
+
+/**
+ * Matches on a HTTP header with a certain value
+ *
+ * @package    Contexts
+ * @subpackage Contexts_Type
+ * @author     Michael Schams <schams.net>
+ * @license    http://opensource.org/licenses/gpl-license GPLv2 or later
+ */
+class Tx_Contexts_Context_Type_HttpHeader extends Tx_Contexts_Context_Abstract
+{
+    /**
+     * Check if the context is active now.
+     *
+     * @param array $arDependencies Array of dependent context objects
+     *
+     * @return boolean True if the context is active, false if not
+     */
+    public function match(array $arDependencies = array())
+    {
+        // determine which HTTP header has been configured
+        $httpHeaderName = trim(strtolower($this->getConfValue('field_name')));
+
+        // check, if header exists in HTTP request
+        foreach ($_SERVER as $header => $value) {
+            if (strtolower($header) === $httpHeaderName) {
+
+                // header exists - check if any configured values match
+                return $this->invert($this->storeInSession(
+                    $this->matchValues($value)
+                ));
+            }
+        }
+
+        // HTTP header does not exist
+        return $this->invert(false);
+    }
+
+    /**
+     * Checks if the given value is one of the configured allowed values
+     *
+     * @param string $value Current parameter value
+     *
+     * @return boolean True if the current paramter value is one of the
+     *                 configured values
+     */
+    protected function matchValues($value)
+    {
+        $arValues = explode("\n", trim($this->getConfValue('field_values')));
+
+        //empty value list, so we allow any value
+        if (count($arValues) == 1 && $arValues[0] == '') {
+            return $value !== '';
+        }
+
+        $arValues = array_map('trim', $arValues);
+        return in_array($value, $arValues, true);
+    }
+}

--- a/Configuration/flexform/ContextType/HttpHeader.xml
+++ b/Configuration/flexform/ContextType/HttpHeader.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<T3DataStructure>
+    <meta>
+        <langDisable>1</langDisable>
+    </meta>
+
+    <ROOT>
+        <type>array</type>
+        <el>
+            <field_name>
+                <TCEforms>
+                    <label>LLL:EXT:contexts/Resources/Private/Language/flexform.xml:httpheader.field_name</label>
+                    <config>
+                        <type>input</type>
+                        <size>30</size>
+                        <eval>trim</eval>
+                    </config>
+                </TCEforms>
+            </field_name>
+
+            <field_values>
+                <TCEforms>
+                    <label>LLL:EXT:contexts/Resources/Private/Language/flexform.xml:httpheader.field_values</label>
+                    <config>
+                        <type>text</type>
+                        <cols>60</cols>
+                        <rows>5</rows>
+                        <eval>trim</eval>
+                    </config>
+                </TCEforms>
+            </field_values>
+        </el>
+    </ROOT>
+</T3DataStructure>

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,17 @@ Supported notations:
 - Wildcards: ``80.76.201.*``, ``80.76.*.37``, ``80.76.*.*``
 
 
+HTTP header
+===========
+Checks if a HTTP header is available and has a certain value.
+
+Activate "Store result in user session" to keep the context when navigating
+between pages.
+
+When leaving the parameter values field empty, any non-empty parameter value
+will activate the context.
+
+
 Logical context combination
 ===========================
 Combines other contexts with logical operators.

--- a/Resources/Private/Language/flexform.xml
+++ b/Resources/Private/Language/flexform.xml
@@ -14,6 +14,8 @@
       <label index="getparam.field_name">GET parameter name</label>
       <label index="getparam.field_values">Parameter values: one per line, empty for any value</label>
       <label index="ip.field_ip">User IP, one per line. * and partial IPs allowed</label>
+      <label index="httpheader.field_name">HTTP header name</label>
+      <label index="httpheader.field_values">Header values: one per line, empty for any value</label>
       <label index="combination.field_logicalExpression">Logical expression combination, (use context alias to combine) </label>
       <label index="session.field_variable">Session variable</label>
     </languageKey>

--- a/ext_autoload.php
+++ b/ext_autoload.php
@@ -17,6 +17,7 @@ return array(
     'tx_contexts_context_type_getparam' => $extensionClassesPath . 'Context/Type/GetParam.php',
     'tx_contexts_context_type_getparam_tsfeservice' => $extensionClassesPath . 'Context/Type/GetParam/TsfeService.php',
     'tx_contexts_context_type_ip' => $extensionClassesPath . 'Context/Type/Ip.php',
+    'tx_contexts_context_type_httpheader' => $extensionClassesPath . 'Context/Type/HttpHeader.php',
     'tx_contexts_context_type_combination' => $extensionClassesPath . 'Context/Type/Combination.php',
     'tx_contexts_context_type_combination_logicalexpressionevaluator' => $extensionClassesPath . 'Context/Type/Combination/LogicalExpressionEvaluator.php',
     'tx_contexts_context_type_combination_logicalexpressionevaluator_exception' => $extensionClassesPath . 'Context/Type/Combination/LogicalExpressionEvaluator/Exception.php',

--- a/ext_contexts.php
+++ b/ext_contexts.php
@@ -26,6 +26,12 @@ Tx_Contexts_Api_Configuration::registerContextType(
     'FILE:EXT:contexts/Configuration/flexform/ContextType/Ip.xml'
 );
 Tx_Contexts_Api_Configuration::registerContextType(
+    'httpheader',
+    'HTTP header',
+    'Tx_Contexts_Context_Type_HttpHeader',
+    'FILE:EXT:contexts/Configuration/flexform/ContextType/HttpHeader.xml'
+);
+Tx_Contexts_Api_Configuration::registerContextType(
     'combination',
     'Logical context combination',
     'Tx_Contexts_Context_Type_Combination',


### PR DESCRIPTION
This change implements a new context type which allows integrators to create contexts to check **HTTP headers** and their values passed in the request to the TYPO3 CMS instance.

This is for example useful if a proxy server in front of the TYPO3 instance adds certain HTTP headers to the request in order to identify the website visitor. Amazon Web Services CDN solution *AWS CloudFront* can be configured to add the country code (e.g. DE for Germany, AU for Australia, etc.) to the header for example, which allows for showing or hiding content depending on the country the user comes from - without the need of GeoIP or other libraries.

The context type allows to check **any** header passed in the request, so other use cases are conceivable and achievable.