### PR TITLE
[BUGFIX] Preserve original override icon

### DIFF
--- a/Classes/Service/IconService.php
+++ b/Classes/Service/IconService.php
@@ -72,5 +72,7 @@ class IconService implements SingletonInterface
             $status['contexts'] = true;
             return 'extensions-contexts-status-overlay-contexts';
         }
+        
+        return $iconName;
     }
 }


### PR DESCRIPTION
Let the hook postOverlayPriorityLookup respect already existing page override icons (like hidden status) if no context is set.

Closes #11 