### PR TITLE
[TASK] Add "renderType" to contexts "type"

### DIFF
--- a/Configuration/TCA/tx_contexts_contexts.php
+++ b/Configuration/TCA/tx_contexts_contexts.php
@@ -59,6 +59,7 @@ return array(
             'label' => $lf . ':tx_contexts_contexts.type',
             'config' => array(
                 'type' => 'select',
+                'renderType' => 'selectSingle',
 //                'items' => array(
 //                    array($lf . ':tx_contexts_contexts.type.select_type', '')
 //                ),


### PR DESCRIPTION
Fixes the following deprecation message:

> Using select fields without the "renderType" setting is deprecated in table "tx_contexts_contexts" and column "type"