### PR TITLE
fix: confine E2E router static-file path to document root (#141)

### DIFF
--- a/Build/Scripts/router.php
+++ b/Build/Scripts/router.php
@@ -24,16 +24,21 @@
 
 declare(strict_types=1);
 
-$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-$file = __DIR__ . '/../../.Build/Web' . $path;
+$path    = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$path    = is_string($path) ? $path : ''; // parse_url() returns false on a malformed URI, null when absent
+$docRoot = realpath(__DIR__ . '/../../.Build/Web');
+$file    = $docRoot === false ? false : realpath($docRoot . $path);
 
-// Serve static files directly.
-// Rationale for nosemgrep below: this script is the PHP built-in server router
-// used only for local E2E tests (`php -S 0.0.0.0:8080 -t .Build/Web Build/Scripts/router.php`).
-// It is never deployed and never internet-facing. `is_file()` only performs a
-// stat probe — no file contents are read or included based on the request URI;
-// the actual `require` below targets a hardcoded path. Tracked in issue #141.
-if (is_file($file)) { // nosemgrep: php.lang.security.injection.tainted-filename.tainted-filename
+// Serve existing static files directly, but only when the resolved real path
+// stays inside the document root. Confining the request-derived path with
+// realpath() both hardens this dev server against path traversal and breaks the
+// taint flow from REQUEST_URI to the is_file() sink (resolves issue #141).
+if (
+    $file !== false
+    && $docRoot !== false
+    && str_starts_with($file, $docRoot . DIRECTORY_SEPARATOR)
+    && is_file($file)
+) {
     return false;
 }
 


### PR DESCRIPTION
## Description

`Build/Scripts/router.php` is the PHP built-in server router used only for local E2E testing. It derived a filesystem path directly from `$_SERVER['REQUEST_URI']` and passed it to `is_file()`, which Opengrep flags as `php.lang.security.injection.tainted-filename.tainted-filename` (CWE-918). The inline `nosemgrep` suppression added in #140 did **not** reliably clear the gate — code-scanning alert [#49](https://github.com/netresearch/t3x-contexts/security/code-scanning/49) remained open on the suppressed line.

This resolves the finding at the source instead of suppressing it:

- Resolve the request path with `realpath()` and only serve the file when the resolved real path stays inside the `.Build/Web` document root.
- This breaks the taint flow from the request URI to the `is_file()` sink, so the rule no longer fires — independent of whether the Opengrep engine/registry honors inline suppression.
- It also hardens the dev server against path traversal: previously a request like `/../secret.txt` resolving to an existing file would have been served directly. Now any path resolving outside the document root falls through to TYPO3's `index.php` (404).

The `nosemgrep` comment is removed since it is no longer needed.

## Related Issue

Fixes #141

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

Verified locally with the **exact pinned Opengrep v1.19.0** binary and the CI gate arguments (`--config auto --error --severity WARNING`):

| State | Result |
| --- | --- |
| Unguarded `is_file($file)` (no suppression) | **1 finding** (rule confirmed firing) |
| This fix (realpath + docroot guard) | **0 findings** across 23 rules |

- `php -l Build/Scripts/router.php` → no syntax errors.
- Routing decision unit-checked: existing static file served; query strings handled; missing routes fall through to `index.php`; `/../` and nested traversal rejected.

Runtime PHPUnit/PHPStan/CGL suites are unaffected — this changes only a dev-only E2E helper script.

## Checklist

- [x] My code follows the project's coding standards
- [x] Change verified with the project's actual SAST tool/version
