### PR TITLE
fix(tests): remove empty setUp() delegating only to parent

### DIFF
--- a/Tests/Unit/Classes/Context/Type/SessionContextTest.php
+++ b/Tests/Unit/Classes/Context/Type/SessionContextTest.php
@@ -30,11 +30,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class SessionContextTest extends UnitTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     #[Test]
     public function matchReturnsFalseWithoutFrontendController(): void
     {


### PR DESCRIPTION
## Problem
`ci / Rector` fails on `main`. Rector 2.5.8 (unpinned; TYPO3 extensions do not commit `composer.lock`) added `RemoveParentDelegatingClassMethodRector`, which flags `SessionContextTest::setUp()` — it only calls `parent::setUp()`.

## Fix
Remove the redundant override; the parent `setUp()` runs unchanged.

## Verification
`vendor/bin/rector process --dry-run --config=Build/rector.php` locally with Rector 2.5.8: `[OK] Rector is done!`, exit 0.