### PR TITLE
ci: drop the deprecated GITLEAKS_LICENSE secret mapping

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,8 +27,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   zizmor:
     uses: netresearch/.github/.github/workflows/zizmor.yml@main


### PR DESCRIPTION
Syncs the template change from netresearch/.github#330.

Secret scanning runs on **betterleaks**, which is OSS and needs no license.
The shared reusable declares `GITLEAKS_LICENSE` only for backwards
compatibility and **never reads it**, so forwarding a repo secret into it was
dead plumbing that widened the secret exposure surface for no benefit.

The file was byte-identical to the previous template revision before this
change, so the diff is exactly the removed `secrets:` mapping — no
repo-specific drift was touched. Required to keep `check-template-drift` green.
