### PR TITLE
fix: gate the debug output with a value, not an unparsable condition

### DIFF
--- a/Configuration/Sets/Contexts/setup.typoscript
+++ b/Configuration/Sets/Contexts/setup.typoscript
@@ -1,11 +1,21 @@
 # TypoScript setup for contexts extension Site Set
 # This file is automatically included when the Site Set is activated
 
-# Context debugging output (only when enabled via Site Set settings)
-[{$contexts.debug} == 1]
+# Context debugging output, gated by the site setting.
+#
+# Deliberately NOT a TypoScript condition. Conditions have been Symfony
+# ExpressionLanguage since TYPO3 12 and do not resolve {$constant}, so the
+# previous `[{$contexts.debug} == 1]` could not be parsed — and because the
+# include tree is walked per request, it logged that failure twice on every
+# single hit, in the backend as well as the frontend. It never gated anything
+# either: a condition that fails to parse does not match, so the debug output
+# was unreachable regardless of the setting.
+#
+# A value-level `if` needs no condition: constants are substituted in TypoScript
+# values as they always were. Both states are covered by
+# Tests/Functional/SiteSetTypoScriptTest.php.
 page.headerData.1700000001 = TEXT
 page.headerData.1700000001 {
     value = <!-- Contexts Extension Debug Mode Active -->
-    wrap = |
+    if.isTrue = {$contexts.debug}
 }
-[global]

--- a/Tests/Functional/SiteSetTypoScriptTest.php
+++ b/Tests/Functional/SiteSetTypoScriptTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package netresearch/contexts.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Netresearch\Contexts\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Yaml\Yaml;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Covers the TypoScript the site set contributes.
+ *
+ * The debug output used to be wrapped in `[{$contexts.debug} == 1]`. TypoScript
+ * conditions are Symfony ExpressionLanguage since TYPO3 12 and do not resolve
+ * `{$constant}`, so that condition failed to parse — on every request, in the
+ * backend as well as the frontend, twice each, because the include tree is
+ * walked per request. It never gated anything; it only produced log noise.
+ *
+ * Replacing it with a value-level `if` has to keep the gate working, which is
+ * what the two rendering tests below establish: the marker appears with the
+ * setting on and is absent with it off.
+ *
+ * Both assertions only mean something because renderWithDebug() flushes the
+ * caches: site configuration, settings and resolved TypoScript are cached for
+ * the lifetime of the shared test instance, so without the flush the second
+ * test reads the first one's setting and reports a gate that does not work.
+ */
+final class SiteSetTypoScriptTest extends FunctionalTestCase
+{
+    private const DEBUG_MARKER = '<!-- Contexts Extension Debug Mode Active -->';
+
+    private const BASE_URL = 'https://contexts.local/';
+
+    protected array $testExtensionsToLoad = [
+        'netresearch/contexts',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'frontend',
+    ];
+
+    #[Test]
+    public function theSetCarriesNoLegacyConstantCondition(): void
+    {
+        $setup = (string) file_get_contents(
+            \dirname(__DIR__, 2) . '/Configuration/Sets/Contexts/setup.typoscript',
+        );
+
+        // A condition line is `[...]` at the start of a line. The parser rejects
+        // a constant inside one, so the set must not contain any.
+        self::assertSame(
+            0,
+            preg_match('/^\[[^\]]*\{\$/m', $setup),
+            'The set must not gate TypoScript with a constant inside a condition',
+        );
+    }
+
+    #[Test]
+    public function theDebugMarkerIsRenderedWhenTheSettingIsOn(): void
+    {
+        self::assertStringContainsString(self::DEBUG_MARKER, $this->renderWithDebug(true));
+    }
+
+    #[Test]
+    public function theDebugMarkerIsAbsentWhenTheSettingIsOff(): void
+    {
+        self::assertStringNotContainsString(self::DEBUG_MARKER, $this->renderWithDebug(false));
+    }
+
+    private function renderWithDebug(bool $debug): string
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/pages.csv');
+
+        $siteConfigPath = $this->instancePath . '/typo3conf/sites/contexts-local';
+        GeneralUtility::mkdir_deep($siteConfigPath);
+        file_put_contents(
+            $siteConfigPath . '/config.yaml',
+            Yaml::dump([
+                'rootPageId' => 1,
+                'base' => self::BASE_URL,
+                // The set is what contributes the TypoScript under test.
+                'dependencies' => ['netresearch/contexts'],
+                'languages' => [[
+                    'languageId' => 0,
+                    'title' => 'English',
+                    'locale' => 'en_US.UTF-8',
+                    'base' => '/',
+                ]],
+            ], 99, 2),
+        );
+        file_put_contents(
+            $siteConfigPath . '/settings.yaml',
+            Yaml::dump(['contexts' => ['debug' => $debug]], 99, 2),
+        );
+
+        // The site configuration, its settings and the resolved TypoScript are
+        // cached, and the cache outlives a single test in the shared instance —
+        // without this flush the second test reads the first one's setting and
+        // the gate appears not to work at all.
+        $cacheManager = $this->get(CacheManager::class);
+        self::assertInstanceOf(CacheManager::class, $cacheManager);
+        $cacheManager->flushCaches();
+
+        // Not setUpFrontendRootPage(): it writes a template with clear = 3, which
+        // discards everything accumulated before it — the site set's TypoScript
+        // among it. clear = 0 lets the set survive, and this template adds only
+        // the page object the set's headerData needs to attach to.
+        $this->getConnectionPool()
+            ->getConnectionForTable('pages')
+            ->update('pages', ['is_siteroot' => 1], ['uid' => 1]);
+        $this->getConnectionPool()
+            ->getConnectionForTable('sys_template')
+            ->insert('sys_template', [
+                'pid' => 1,
+                'root' => 1,
+                'clear' => 0,
+                'title' => 'Page object only',
+                'constants' => '',
+                'config' => "page = PAGE\npage.typeNum = 0\n",
+            ]);
+
+        return (string) $this->executeFrontendSubRequest(
+            (new InternalRequest(self::BASE_URL))->withPageId(1),
+        )->getBody();
+    }
+}


### PR DESCRIPTION
## The bug

`Configuration/Sets/Contexts/setup.typoscript` gated its debug output with

```typoscript
[{$contexts.debug} == 1]
```

TypoScript conditions have been Symfony ExpressionLanguage since TYPO3 12 and do **not** resolve `{$constant}`. The parser rejects the line:

```
TypoScript condition [{$contexts.debug} == 1] could not be parsed:
Unexpected character "$" around position 1
```

Two consequences, both silent:

- **Every request logs it, twice** — the include tree is walked per request, in the backend as much as the frontend. On a TYPO3 14.3 instance running this extension, the log is dominated by this one entry. It is what surfaced the bug: it was the single most frequent line in the backend log of an unrelated installation.
- **The gate never worked.** A condition that fails to parse does not match, so the debug output was unreachable no matter what the setting said.

The setting itself (`contexts.debug`, `type: bool`) migrated to the site set correctly; only the condition around it did not.

## The change

A value-level `if`, which needs no condition at all — constants are substituted in TypoScript *values* exactly as they always were:

```typoscript
page.headerData.1700000001 {
    value = <!-- Contexts Extension Debug Mode Active -->
    if.isTrue = {$contexts.debug}
}
```

## Verification

**Measured on a running TYPO3 14.3 instance** with this extension installed, log truncated before each request:

| `setup.typoscript` | parse errors per request |
|---|---|
| before | **2** |
| after | **0** |

**New functional test** `SiteSetTypoScriptTest`, which is the coverage that was missing and the reason the broken condition survived the migration:

- renders the frontend through the **site set** with `contexts.debug` on, and asserts the marker is present;
- renders it with the setting off, and asserts the marker is gone;
- asserts the set contains no `[…{$…]` condition at all, so the construct cannot come back.

Two things about that test are worth knowing, because both produced false results while writing it:

- It **flushes the caches** between the two states. Site configuration, settings and resolved TypoScript are cached for the lifetime of the shared test instance, so the second test otherwise reads the first one's setting — and a perfectly working gate reports as broken.
- It writes its own `sys_template` with `clear = 0` instead of calling `setUpFrontendRootPage()`, which hardcodes `clear = 3` and discards everything accumulated before it, the site set's TypoScript included. With that, the test would assert against TypoScript the set never contributed.

Suite: 128 functional (7 pre-existing skips), 742 unit, PHPStan, CGL and Rector all green.
