### PR TITLE
ci: sync labeler fork-PR fix from typo3-extension template

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,10 +73,3 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-
-  labeler:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@main
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,11 @@
-name: PR Labeler
+name: Labeler
 
-on:
-  pull_request:
+# pull_request_target is required: labeling fork PRs needs a write-scoped
+# token, which pull_request does not provide. The called reusable workflow
+# only runs actions/labeler (no checkout or execution of untrusted PR code),
+# so the usual pull_request_target risk does not apply here.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions: {}


### PR DESCRIPTION
Template sync for [netresearch/.github#341](https://github.com/netresearch/.github/pull/341): the labeler job moves out of `checks.yml` into a standalone `labeler.yml` triggered by `pull_request_target`, because fork PRs get a read-only `GITHUB_TOKEN` on `pull_request` runs and `actions/labeler` failed with `Resource not accessible by integration` (first seen on [t3x-nr-llm#569](https://github.com/netresearch/t3x-nr-llm/pull/569), [t3x-nr-llm#571](https://github.com/netresearch/t3x-nr-llm/pull/571), [t3x-cowriter#134](https://github.com/netresearch/t3x-cowriter/pull/134)).

The called reusable only applies labels via the base-repo token and never checks out or executes PR head code, so the usual `pull_request_target` risk does not apply. Both files are byte-identical to `netresearch/.github/templates/typo3-extension@main`; this clears the `Template Drift` check that is red since the template change merged.
