### PR TITLE
docs: use --global on the signing-key setup commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,4 +233,4 @@ Nearest AGENTS.md wins. User prompts override files.
 
 ## Commit Signing
 
-Signed commits are required: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch rejects unsigned commits at merge time, and the DCO check additionally requires the `Signed-off-by` trailer. Quickest setup is SSH signing — register your SSH key as a *signing key* on your GitHub account, then `git config gpg.format ssh && git config user.signingkey ~/.ssh/<key>.pub`.
+Signed commits are required: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch rejects unsigned commits at merge time, and the DCO check additionally requires the `Signed-off-by` trailer. Quickest setup is SSH signing — register your SSH key as a *signing key* on your GitHub account, then `git config --global gpg.format ssh && git config --global user.signingkey ~/.ssh/<key>.pub`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,4 +54,4 @@ By contributing, you agree that your contributions will be licensed under the AG
 
 ## Commit Signing
 
-All commits must be cryptographically signed and carry a DCO sign-off: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch enforces the signature (the "Verified" badge on GitHub); the DCO check enforces the `Signed-off-by` trailer — these are two different things and both are required. Quickest setup is SSH signing: register your SSH key as a *signing key* on your GitHub account, then `git config gpg.format ssh && git config user.signingkey ~/.ssh/<key>.pub`.
+All commits must be cryptographically signed and carry a DCO sign-off: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch enforces the signature (the "Verified" badge on GitHub); the DCO check enforces the `Signed-off-by` trailer — these are two different things and both are required. Quickest setup is SSH signing: register your SSH key as a *signing key* on your GitHub account, then `git config --global gpg.format ssh && git config --global user.signingkey ~/.ssh/<key>.pub`.


### PR DESCRIPTION
Follow-up to #165, which merged before the review fix from [t3x-nr-saml-auth#85](https://github.com/netresearch/t3x-nr-saml-auth/pull/85) landed: the signing-key setup is general advice, so the git config commands now use --global, matching every sibling PR of the sweep.