### PR TITLE
fix(rector): adopt the shared org rector config

### DIFF
--- a/Build/rector.php
+++ b/Build/rector.php
@@ -14,46 +14,35 @@
 
 declare(strict_types=1);
 
-use Rector\DeadCode\Rector\Concat\RemoveConcatAutocastRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+use Rector\DeadCode\Rector\Concat\RemoveConcatAutocastRector;
 use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 use Ssch\TYPO3Rector\CodeQuality\General\InjectMethodToConstructorInjectionRector;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
 use Ssch\TYPO3Rector\TYPO314\v0\MigrateLabelReferenceToDomainSyntaxRector;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
-        __DIR__ . '/../Classes',
-        __DIR__ . '/../Configuration',
-        __DIR__ . '/../Tests',
-    ]);
+$configure = require_once __DIR__ . '/../vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
-    $rectorConfig->skip([
-        __DIR__ . '/../ext_emconf.php',
-        __DIR__ . '/../.Build',
-        __DIR__ . '/../vendor',
-    ]);
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: paths, code-quality sets, rule skips,
+    // and the package's ergebnis-free phpstan-rector.neon.
+    $configure($rectorConfig, __DIR__ . '/..');
 
-    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
-    $rectorConfig->importNames();
-    $rectorConfig->removeUnusedImports();
+    // paths() replaces the shared list — re-declared to keep Tests/ in scope,
+    // which the shared $projectRoot default leaves out.
+    $rectorConfig->paths(array_merge(
+        [
+            __DIR__ . '/../Classes',
+            __DIR__ . '/../Configuration',
+            __DIR__ . '/../Resources',
+            __DIR__ . '/../Tests',
+        ],
+        glob(__DIR__ . '/../ext_*.php') ?: [],
+    ));
 
-    // Define what rule sets will be applied - upgrade to PHP 8.2 and TYPO3 v14
     $rectorConfig->sets([
-        // Dead code removal
-        SetList::DEAD_CODE,
-
-        // Code quality improvements
-        SetList::CODE_QUALITY,
-
-        // PHP level upgrades
-        LevelSetList::UP_TO_PHP_82,
-
         // TYPO3 v14 migrations (extension supports ^13.4 || ^14.3).
         //
         // UP_TO_TYPO3_14 is UP_TO_TYPO3_13 plus the TYPO3_14 set. The only
@@ -71,11 +60,7 @@ return static function (RectorConfig $rectorConfig): void {
         Typo3SetList::GENERAL,
     ]);
 
-    // Skip some rules that may cause issues or require manual review
     $rectorConfig->skip([
-        // Skip constructor promotion - keep explicit property declarations for clarity
-        ClassPropertyAssignToConstructorPromotionRector::class,
-
         // Skip removing (string) casts in concatenation — PHPStan level 10 requires
         // explicit casts when concatenating mixed values (from $arRow, $GLOBALS, etc.)
         RemoveConcatAutocastRector::class,

--- a/Classes/Api/ContextMatcher.php
+++ b/Classes/Api/ContextMatcher.php
@@ -52,6 +52,7 @@ class ContextMatcher
         if (!self::$instance instanceof ContextMatcher) {
             self::$instance = new self();
         }
+
         return self::$instance;
     }
 

--- a/Classes/Context/Container.php
+++ b/Classes/Context/Container.php
@@ -242,9 +242,11 @@ class Container extends ArrayObject
                         ];
                         $unresolvedDeps--;
                     }
+
                     // FIXME: what happens when dependency context is not
                     // available at all (e.g. deleted)?
                 }
+
                 if ($unresolvedDeps > 0) {
                     // not all dependencies available yet, so skip this
                     // one for now

--- a/Classes/Context/Setting.php
+++ b/Classes/Context/Setting.php
@@ -23,37 +23,37 @@ namespace Netresearch\Contexts\Context;
  * @license Netresearch https://www.netresearch.de
  * @link    https://www.netresearch.de
  */
-final class Setting
+final readonly class Setting
 {
     /**
      */
-    protected AbstractContext $context;
+    private AbstractContext $context;
 
     /**
      * The uid of the setting record
      */
-    protected int $uid;
+    private int $uid;
 
     /**
      * The name of table the setting is for
      */
-    protected string $foreignTable;
+    private string $foreignTable;
 
     /**
      * The uid of the record the setting is for
      * (0 for default setting)
      */
-    protected int $foreignUid;
+    private int $foreignUid;
 
     /**
      * The name of the setting
      */
-    protected string $name;
+    private string $name;
 
     /**
      * Whether the record is enabled by this setting
      */
-    protected bool $enabled;
+    private bool $enabled;
 
     /**
      */

--- a/Classes/Context/Type/Combination/LogicalExpressionEvaluator.php
+++ b/Classes/Context/Type/Combination/LogicalExpressionEvaluator.php
@@ -544,7 +544,7 @@ class LogicalExpressionEvaluator
                 $token->negated = true;
             } else {
                 throw new LogicalExpressionEvaluatorException(
-                    "! can't preceded operators",
+                    "! can't precede operators",
                     4778280443,
                 );
             }

--- a/Classes/Context/Type/Combination/LogicalExpressionEvaluator.php
+++ b/Classes/Context/Type/Combination/LogicalExpressionEvaluator.php
@@ -202,6 +202,7 @@ class LogicalExpressionEvaluator
                         $lastOperator,
                     ];
                 }
+
                 $operator[0] = '';
             }
 
@@ -284,6 +285,7 @@ class LogicalExpressionEvaluator
                 if (!\array_key_exists($tokenKey, $values)) {
                     $values[$tokenKey] = true;
                 }
+
                 $value = $values[$tokenKey];
                 if ($value === 'disabled') {
                     // context is disabled, so treat it as matching
@@ -292,34 +294,40 @@ class LogicalExpressionEvaluator
                     $value = !$value;
                 }
             }
+
             switch ($this->operator) {
                 case self::T_AND:
                     if (!$value) {
                         break 2;
                     }
+
                     break;
                 case self::T_OR:
                     if ($value) {
                         break 2;
                     }
+
                     break;
                 case self::T_XOR:
                     if ($i > 1) {
                         throw new LogicalExpressionEvaluatorException(
-                            'Can\'t evaluate more than two items by xor',
+                            "Can't evaluate more than two items by xor",
                             3563712913,
                         );
                     }
+
                     if ($i === 0) {
                         $lastValue = $value;
                     } else {
                         $value = $value !== $lastValue;
                     }
+
                     break;
                 default:
                     break 2;
             }
         }
+
         return $this->negated ? !$value : $value;
     }
 
@@ -340,6 +348,7 @@ class LogicalExpressionEvaluator
                 if ($token->parentScope instanceof LogicalExpressionEvaluator) {
                     $str = '(' . $str . ')';
                 }
+
                 if ($token->negated) {
                     $str = '!' . $str;
                 }
@@ -358,6 +367,7 @@ class LogicalExpressionEvaluator
                 $str = '?';
                 // @codeCoverageIgnoreEnd
             }
+
             $parts[] = $str;
         }
 
@@ -474,6 +484,7 @@ class LogicalExpressionEvaluator
                         1651471071,
                     );
                 }
+
                 $this->pushToken($token);
                 break;
 
@@ -506,6 +517,7 @@ class LogicalExpressionEvaluator
                                 7706253055,
                             );
                         }
+
                         $this->pushToken($token);
                     } else {
                         throw new LogicalExpressionEvaluatorException(
@@ -532,12 +544,14 @@ class LogicalExpressionEvaluator
                 $token->negated = true;
             } else {
                 throw new LogicalExpressionEvaluatorException(
-                    '! can\'t preceded operators',
+                    "! can't preceded operators",
                     4778280443,
                 );
             }
+
             $this->nextTokenNegated = false;
         }
+
         $this->tokens[] = $token;
     }
 

--- a/Classes/Context/Type/CombinationContext.php
+++ b/Classes/Context/Type/CombinationContext.php
@@ -98,8 +98,10 @@ class CombinationContext extends AbstractContext
             if ($dependency->context->getAlias() !== '') {
                 $values[$dependency->context->getAlias()] = $dependency->matched;
             }
+
             $values[$dependency->context->getUid()] = $dependency->matched;
         }
+
         // TODO: Should we try/catch parsing and evaluation?
         return $this->invert($this->evaluator->evaluate($values));
     }

--- a/Classes/Context/Type/IpContext.php
+++ b/Classes/Context/Type/IpContext.php
@@ -66,6 +66,7 @@ class IpContext extends AbstractContext
         if (\count($arIpRange) === 1 && $arIpRange[0] === '') {
             return $this->invert(false);
         }
+
         // @codeCoverageIgnoreEnd
 
         $strRange = implode(',', $arIpRange);

--- a/Classes/ExpressionLanguage/FunctionsProvider/ContextFunctionsProvider.php
+++ b/Classes/ExpressionLanguage/FunctionsProvider/ContextFunctionsProvider.php
@@ -48,7 +48,7 @@ class ContextFunctionsProvider implements ExpressionFunctionProviderInterface
             static function (): void {
                 // Not implemented, we only use the evaluators
             },
-            fn($arguments, $strContext) => ContextMatcher::getInstance()->matches((string) $strContext),
+            fn($arguments, $strContext): bool => ContextMatcher::getInstance()->matches((string) $strContext),
         );
     }
 }

--- a/Classes/Form/RecordSettingsFormElement.php
+++ b/Classes/Form/RecordSettingsFormElement.php
@@ -97,7 +97,11 @@ class RecordSettingsFormElement extends AbstractFormElement
 
         /* @var AbstractContext $context */
         foreach ($contexts as $context) {
-            if ($context->getDisabled() || $context->getHideInBackend()) {
+            if ($context->getDisabled()) {
+                continue;
+            }
+
+            if ($context->getHideInBackend()) {
                 continue;
             }
 
@@ -140,6 +144,7 @@ class RecordSettingsFormElement extends AbstractFormElement
                 . $contSettings
                 . '</tr>';
         }
+
         if ($visibleContexts === 0) {
             $noContextsLabel = $this->getLanguageService()->sL('LLL:' . Configuration::LANG_FILE . ':no_contexts');
             $content .= <<<HTML

--- a/Classes/Service/DataHandlerService.php
+++ b/Classes/Service/DataHandlerService.php
@@ -180,6 +180,7 @@ class DataHandlerService
                 if (isset($flatSettingColumns[$field])) {
                     continue;
                 }
+
                 $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_contexts_contexts');
                 $row = $queryBuilder->select('uid')
                     ->from('tx_contexts_settings')
@@ -326,6 +327,7 @@ class DataHandlerService
                     $fieldSettings[$setting['name']] = $setting['uid'];
                 }
             }
+
             $connenction = $connectionPool->getConnectionForTable('tx_contexts_settings');
             foreach ($fields as $field => $enabled) {
                 $field = (string) $field;

--- a/Classes/Service/InstallService.php
+++ b/Classes/Service/InstallService.php
@@ -57,6 +57,7 @@ class InstallService
                 if (\is_array($setting)) {
                     continue;
                 }
+
                 $setting = (string) $setting;
                 $flatColumns = Configuration::getFlatColumns($table, $setting);
                 $arSql[] = (string) $flatColumns[0] . ' tinytext';

--- a/Classes/ViewHelpers/MatchesViewHelper.php
+++ b/Classes/ViewHelpers/MatchesViewHelper.php
@@ -69,6 +69,7 @@ class MatchesViewHelper extends AbstractViewHelper
         if ($alias !== null) {
             return (int) ContextMatcher::getInstance()->matches($alias);
         }
+
         return 0;
     }
 }

--- a/Tests/Functional/ContextCachingAndSessionTest.php
+++ b/Tests/Functional/ContextCachingAndSessionTest.php
@@ -173,6 +173,7 @@ final class ContextCachingAndSessionTest extends FunctionalTestCase
         $configTree = new RootNode();
         $linkVars = new ChildNode('linkVars');
         $linkVars->setValue('L');
+
         $configTree->addChild($linkVars);
 
         $event = new ModifyTypoScriptConfigEvent(

--- a/Tests/Functional/Integration/CrossExtensionIntegrationTest.php
+++ b/Tests/Functional/Integration/CrossExtensionIntegrationTest.php
@@ -71,6 +71,7 @@ final class CrossExtensionIntegrationTest extends FunctionalTestCase
         if ($this->hasGeolocationExtension) {
             $this->testExtensionsToLoad[] = 'netresearch/contexts-geolocation';
         }
+
         if ($this->hasDeviceExtension) {
             $this->testExtensionsToLoad[] = 'netresearch/contexts-wurfl';
         }
@@ -280,7 +281,11 @@ final class CrossExtensionIntegrationTest extends FunctionalTestCase
 
         foreach ($contextTypes as $type => $config) {
             $className = (string) ($config['class'] ?? '');
-            if ($className === '' || !class_exists($className)) {
+            if ($className === '') {
+                continue;
+            }
+
+            if (!class_exists($className)) {
                 continue;
             }
 

--- a/Tests/Fuzz/QueryParameterFuzz.php
+++ b/Tests/Fuzz/QueryParameterFuzz.php
@@ -59,6 +59,7 @@ return function (string $data): void {
         if (isset($_GET[$paramName])) {
             unset($_GET[$paramName]);
         }
+
         if (isset($_REQUEST[$paramName])) {
             unset($_REQUEST[$paramName]);
         }

--- a/Tests/Unit/Classes/Context/AbstractContextTest.php
+++ b/Tests/Unit/Classes/Context/AbstractContextTest.php
@@ -1011,6 +1011,7 @@ final class AbstractContextTest extends UnitTestCase
                 if ($key === 'contexts-101-1000000001') {
                     return true;
                 }
+
                 if ($key === 'contexts-102-1000000002') {
                     return false;
                 }

--- a/Tests/Unit/Classes/Context/Type/Combination/LogicalExpressionEvaluatorTest.php
+++ b/Tests/Unit/Classes/Context/Type/Combination/LogicalExpressionEvaluatorTest.php
@@ -427,7 +427,7 @@ final class LogicalExpressionEvaluatorTest extends UnitTestCase
     public function runWithExceptionNegatedOperator(): void
     {
         $this->expectException(LogicalExpressionEvaluatorException::class);
-        $this->expectExceptionMessage("! can't preceded operators");
+        $this->expectExceptionMessage("! can't precede operators");
 
         // This creates a situation where ! precedes an operator
         $strExpression = 'a !&& b';

--- a/Tests/Unit/Classes/Context/Type/CombinationContextTest.php
+++ b/Tests/Unit/Classes/Context/Type/CombinationContextTest.php
@@ -54,6 +54,7 @@ final class CombinationContextTest extends TestBase
             'XOR both false' => ['ctx1 >< ctx2', false, false, false],
         ];
     }
+
     // -----------------------------------------------------------------------
     // getDependencies() tests
     // -----------------------------------------------------------------------

--- a/Tests/Unit/Classes/Context/Type/DomainContextTest.php
+++ b/Tests/Unit/Classes/Context/Type/DomainContextTest.php
@@ -46,6 +46,7 @@ final class DomainContextTest extends TestBase
         } else {
             unset($_SERVER['HTTP_HOST']);
         }
+
         parent::tearDown();
     }
 
@@ -334,6 +335,7 @@ final class DomainContextTest extends TestBase
             if ($originalHttpHost !== null) {
                 $_SERVER['HTTP_HOST'] = $originalHttpHost;
             }
+
             Container::reset();
         }
     }

--- a/Tests/Unit/Classes/Context/Type/IpContextTest.php
+++ b/Tests/Unit/Classes/Context/Type/IpContextTest.php
@@ -43,6 +43,7 @@ final class IpContextTest extends TestBase
         } else {
             unset($_SERVER['REMOTE_ADDR']);
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Classes/Context/Type/SessionContextTest.php
+++ b/Tests/Unit/Classes/Context/Type/SessionContextTest.php
@@ -122,6 +122,7 @@ final class SessionContextTest extends UnitTestCase
     {
         $obj = new stdClass();
         $obj->property = 'value';
+
         $context = $this->createSessionContext('my_session_var', $obj, true);
 
         self::assertTrue($context->match(), 'Object value session variable should match (is set)');
@@ -240,6 +241,7 @@ final class SessionContextTest extends UnitTestCase
                 if ($fieldNameArg === 'field_variable') {
                     return $this->mockVariableName;
                 }
+
                 return $default;
             }
 

--- a/Tests/Unit/Classes/EventListener/PageAccessEventListenerTest.php
+++ b/Tests/Unit/Classes/EventListener/PageAccessEventListenerTest.php
@@ -459,6 +459,7 @@ final class PageAccessEventListenerTest extends UnitTestCase
         $pageInformation1 = new PageInformation();
         $pageInformation1->setPageRecord([]);
         $pageInformation1->setRootLine([]);
+
         $event1 = new AfterPageAndLanguageIsResolvedEvent($request, $pageInformation1);
         $listener($event1);
 
@@ -507,6 +508,7 @@ final class PageAccessEventListenerTest extends UnitTestCase
         $pageInfo1 = new PageInformation();
         $pageInfo1->setPageRecord(['uid' => 1, 'title' => 'Page 1']);
         $pageInfo1->setRootLine([1 => ['uid' => 1, 'title' => 'Page 1']]);
+
         $event1 = new AfterPageAndLanguageIsResolvedEvent($request, $pageInfo1);
         $listener($event1);
 
@@ -514,6 +516,7 @@ final class PageAccessEventListenerTest extends UnitTestCase
         $pageInfo2 = new PageInformation();
         $pageInfo2->setPageRecord(['uid' => 2, 'title' => 'Page 2']);
         $pageInfo2->setRootLine([1 => ['uid' => 2, 'title' => 'Page 2']]);
+
         $event2 = new AfterPageAndLanguageIsResolvedEvent($request, $pageInfo2);
         $listener($event2);
 

--- a/Tests/Unit/Classes/Form/RecordSettingsFormElementTest.php
+++ b/Tests/Unit/Classes/Form/RecordSettingsFormElementTest.php
@@ -922,7 +922,11 @@ class TestableRecordSettingsFormElement extends RecordSettingsFormElement
         $visibleContexts = 0;
 
         foreach ($contexts as $context) {
-            if ($context->getDisabled() || $context->getHideInBackend()) {
+            if ($context->getDisabled()) {
+                continue;
+            }
+
+            if ($context->getHideInBackend()) {
                 continue;
             }
 

--- a/Tests/Unit/Classes/Query/Restriction/ContextRestrictionTest.php
+++ b/Tests/Unit/Classes/Query/Restriction/ContextRestrictionTest.php
@@ -20,6 +20,7 @@ use Netresearch\Contexts\Context\AbstractContext;
 use Netresearch\Contexts\Context\Container;
 use Netresearch\Contexts\Query\Restriction\ContextRestriction;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
@@ -253,13 +254,13 @@ final class ContextRestrictionTest extends UnitTestCase
 
         $expressionBuilder->expects(self::once())
             ->method('eq')
-            ->with('tx_contexts_enable', '\'\'')
-            ->willReturn('= \'\'');
+            ->with('tx_contexts_enable', "''")
+            ->willReturn("= ''");
 
         $expressionBuilder->expects(self::once())
             ->method('literal')
             ->with('')
-            ->willReturn('\'\'');
+            ->willReturn("''");
 
         // Should create OR expression for enable constraints only
         $expressionBuilder->expects(self::once())
@@ -314,17 +315,17 @@ final class ContextRestrictionTest extends UnitTestCase
 
         $expressionBuilder->expects(self::exactly(2))
             ->method('eq')
-            ->willReturn('= \'\'');
+            ->willReturn("= ''");
 
         $expressionBuilder->expects(self::exactly(2))
             ->method('literal')
             ->with('')
-            ->willReturn('\'\'');
+            ->willReturn("''");
 
         // Should build inSet for both enable and disable columns
         $expressionBuilder->expects(self::exactly(2))
             ->method('inSet')
-            ->willReturnCallback(fn($column, $value) => 'FIND_IN_SET(' . (string) $value . ', ' . (string) $column . ')');
+            ->willReturnCallback(fn($column, $value): string => 'FIND_IN_SET(' . (string) $value . ', ' . (string) $column . ')');
 
         // Should create OR expressions: one for enable, one for disable
         $expressionBuilder->expects(self::exactly(2))
@@ -498,14 +499,14 @@ final class ContextRestrictionTest extends UnitTestCase
         $inSetCalls = [];
         $expressionBuilder->expects(self::exactly(2))
             ->method('inSet')
-            ->willReturnCallback(function ($column, $value) use (&$inSetCalls) {
+            ->willReturnCallback(function ($column, $value) use (&$inSetCalls): string {
                 $inSetCalls[] = ['column' => $column, 'value' => $value];
                 return 'FIND_IN_SET(' . (string) $value . ', ' . (string) $column . ')';
             });
 
         $expressionBuilder->method('isNull')->willReturn('IS NULL');
-        $expressionBuilder->method('eq')->willReturn('= \'\'');
-        $expressionBuilder->method('literal')->willReturn('\'\'');
+        $expressionBuilder->method('eq')->willReturn("= ''");
+        $expressionBuilder->method('literal')->willReturn("''");
         $expressionBuilder->method('or')->willReturn($orExpression);
         $expressionBuilder->method('and')->willReturn($compositeExpression);
 
@@ -538,7 +539,7 @@ final class ContextRestrictionTest extends UnitTestCase
     /**
      * Create a mock context with specified UID
      */
-    private function createMockContext(int $uid): object
+    private function createMockContext(int $uid): MockObject
     {
         $context = $this->getMockBuilder(AbstractContext::class)
             ->disableOriginalConstructor()

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
             "typo3/class-alias-loader": true,
             "a9f/fractor-extension-installer": true,
             "infection/extension-installer": true,
-            "captainhook/hook-installer": true
+            "captainhook/hook-installer": true,
+            "phpstan/extension-installer": false
         },
         "audit": {
             "abandoned": "ignore",
@@ -55,6 +56,7 @@
         "captainhook/hook-installer": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.92",
         "infection/infection": "*",
+        "netresearch/typo3-ci-workflows": "^1.3",
         "nikic/php-fuzzer": "^0.0.11",
         "phpat/phpat": "^0.12",
         "phpstan/phpstan": "^2.1",

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -18,6 +18,7 @@ use Netresearch\Contexts\Form\CombinationFormElement;
 use Netresearch\Contexts\Form\DefaultSettingsFormElement;
 use Netresearch\Contexts\Form\RecordSettingsFormElement;
 use Netresearch\Contexts\Query\Restriction\ContextRestriction;
+use Netresearch\Contexts\Service\DataHandlerService;
 use Netresearch\Contexts\Xclass\Backend\Tree\Repository\PageTreeRepository;
 
 defined('TYPO3') || die('Access denied.');
@@ -59,9 +60,9 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1700000003] = [
 // DataHandler hooks for processing context settings during record save/update
 // Note: DataHandler still uses SC_OPTIONS hooks in v14, not PSR-14 events
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['contexts']
-    = Netresearch\Contexts\Service\DataHandlerService::class;
+    = DataHandlerService::class;
 
 // Command map hook: a deleted, undeleted, copied or moved context record must
 // invalidate the frontend caches just like an edited one does.
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['contexts']
-    = Netresearch\Contexts\Service\DataHandlerService::class;
+    = DataHandlerService::class;


### PR DESCRIPTION
`Build/rector.php` declared its own base rule sets and rule skips instead of building on the shared org config. That is what made the Rector 2.6.0 fleet breakage of 2026-08-03 a per-repo fix: the release removed `SetList::STRICT_BOOLEANS`, every extension that listed it died with `Undefined constant`, and each copy had to be corrected separately. Org policy is that [netresearch/typo3-ci-workflows](https://github.com/netresearch/typo3-ci-workflows) defines the Rector rule baseline, so the next upstream change is handled in one place. This follows the same conversion as [t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150).

The config now delegates to `config/rector/rector.php` of [typo3-ci-workflows v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4) and keeps only what is genuinely specific to this extension: `Tests/` in the scan paths (the shared `$projectRoot` default leaves it out and `paths()` replaces rather than merges), the `UP_TO_TYPO3_14` level set together with the comment explaining why it is safe while the extension still supports v13.4, the TYPO3 code-quality and general sets, and the five repo-specific rule skips (`RemoveConcatAutocastRector`, `RemoveParentCallWithoutParentRector`, the event-listener scoped `RemoveUnusedPublicMethodParameterRector`, the `RecordSettingsFormElement` scoped `InjectMethodToConstructorInjectionRector`, and `MigrateLabelReferenceToDomainSyntaxRector`). Everything the shared config already provides is gone: the base `SetList` sets, `UP_TO_PHP_82`, `ClassPropertyAssignToConstructorPromotionRector`, `importNames()`, `removeUnusedImports()`, the `phpVersion` and the PHPStan config.

One side effect needed handling. `netresearch/typo3-ci-workflows` transitively requires `phpstan/extension-installer`, and its auto-registration collides with the explicit plugin includes in `Build/phpstan.neon` and `Build/phpat.neon` ("This file is included multiple times"). Removing those includes instead would newly activate `saschaegerer/phpstan-typo3` and `ergebnis/phpstan-rules` with its `allRules` default, which produces 534 findings in this codebase. The plugin is therefore switched off via `allow-plugins`, leaving PHPStan behaviour byte-for-byte as it was. Adopting the shared PHPStan config is worth doing but belongs in its own PR.

The 23 source and test files in this diff are Rector's own output, applied until `--dry-run` reached a fixed point, plus the `php-cs-fixer` follow-up on two of them. Nearly all of it is `NewlineAfterStatementRector` blank lines; the substantive ones are `Classes/Context/Setting.php` becoming a `final readonly` class with private properties (a value object that is only ever written in its constructor, never cloned or unserialized), an early-return split in `RecordSettingsFormElement`, and an import of `DataHandlerService` in `ext_localconf.php`.

Verified with a cold install on a CI-matched toolchain (`platform.php` temporarily pinned to 8.2.33, resolving Rector 2.6.1, typo3-rector 3.14.4, PHPUnit 11.5.56): `rector --dry-run` exit 0, `php-cs-fixer --dry-run` exit 0, PHPStan level 10 with no errors, and 742 unit tests with 1209 assertions passing. Functional tests need a database and were not run locally; CI covers them. No version bump and no CHANGELOG entry, since versioning belongs to the release flow.

Checked explicitly, because `SetList::PRIVATIZATION` from the shared config lets `PrivatizeFinalClassPropertyRector` rewrite `protected` properties to `private` in `final` classes, which is fatal for Extbase domain models: the DataMapper hydrates through `AbstractDomainObject::_setProperty()`, which assigns from the parent-class scope and dies with "Cannot access private property". This extension contains no Extbase code at all — no `Classes/Domain/Model/`, and no class anywhere under `Classes/` extends `AbstractDomainObject`, `AbstractEntity`, `AbstractValueObject`, `FileReference` or an Extbase `Repository`. The one class Rector privatized, `Classes/Context/Setting.php`, was already `final`, extends nothing, and is only ever constructed via `new Setting($context, $row)` or its own `fromFlatData()` factory. No skip for that rule is therefore needed here.
