### PR TITLE
chore(deps): drop dev-dependencies the shared package already provides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
             "typo3/cms-composer-installers": true,
             "typo3/class-alias-loader": true,
             "a9f/fractor-extension-installer": true,
+            "ergebnis/composer-normalize": true,
             "infection/extension-installer": true,
             "captainhook/hook-installer": true,
             "phpstan/extension-installer": false
@@ -51,23 +52,9 @@
         "typo3/cms-frontend": "^13.4 || ^14.3"
     },
     "require-dev": {
-        "a9f/typo3-fractor": "^0.5.8 || ^1.0.0",
-        "captainhook/captainhook": "^5.28",
-        "captainhook/hook-installer": "^1.0",
-        "friendsofphp/php-cs-fixer": "^3.92",
-        "infection/infection": "*",
         "netresearch/typo3-ci-workflows": "^1.3",
-        "nikic/php-fuzzer": "^0.0.11",
-        "phpat/phpat": "^0.12",
-        "phpstan/phpstan": "^2.1",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0",
-        "rector/rector": "^2.3",
-        "squizlabs/php_codesniffer": "^4.0",
-        "ssch/typo3-rector": "^3.11",
-        "typo3/testing-framework": "^8.0 || ^9.0"
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Third of the fleet-wide dedup pass, after [t3x-nr-passkeys-fe#46](https://github.com/netresearch/t3x-nr-passkeys-fe/pull/46) and [t3x-nr-extension-scanner-cli#29](https://github.com/netresearch/t3x-nr-extension-scanner-cli/pull/29). Companion to [netresearch/typo3-ci-workflows#158](https://github.com/netresearch/typo3-ci-workflows/pull/158).

## What is removed

Fourteen tools declared both here and by `netresearch/typo3-ci-workflows`, which this repo requires. Composer intersects consumer and shared constraint and the narrower wins, so each copy is a place where a future narrowing holds an update back unnoticed — as happened in [t3x-contexts_wurfl](https://github.com/netresearch/t3x-contexts_wurfl/pull/44), where a local `^2.0` kept `saschaegerer/phpstan-typo3` off 3.x while every other consumer had it.

Two lines were doing something on their own, and neither survives scrutiny:

- `infection/infection: "*"` — wider than anything the shared package states, so the intersection was the shared constraint regardless.
- `a9f/typo3-fractor: ^0.5.8 || ^1.0.0` — the 0.5.x alternative had already been discarded by the intersection with the shared `^1.0`.

`phpunit/phpunit` and `squizlabs/php_codesniffer` stay: this repo declares them for itself and the shared package does not ship them.

## What is added

`ergebnis/composer-normalize` under `config.allow-plugins` — the shared package picks it up in #158, and an unallowed Composer plugin installs but never runs.

## Verification

```
$ composer update --dry-run --no-scripts --no-plugins --ignore-platform-reqs
before: 376 packages
after:  376 packages
$ diff before after
(empty)
```

`composer validate` clean.