### PR TITLE
fix: create QueryBuilder for the queried table in DataHandlerService

### DIFF
--- a/Classes/Service/DataHandlerService.php
+++ b/Classes/Service/DataHandlerService.php
@@ -181,7 +181,7 @@ class DataHandlerService
                     continue;
                 }
 
-                $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_contexts_contexts');
+                $queryBuilder = $connectionPool->getQueryBuilderForTable('tx_contexts_settings');
                 $row = $queryBuilder->select('uid')
                     ->from('tx_contexts_settings')
                     ->where(
@@ -328,18 +328,18 @@ class DataHandlerService
                 }
             }
 
-            $connenction = $connectionPool->getConnectionForTable('tx_contexts_settings');
+            $connection = $connectionPool->getConnectionForTable('tx_contexts_settings');
             foreach ($fields as $field => $enabled) {
                 $field = (string) $field;
                 if (\array_key_exists($field, $fieldSettings)) {
-                    $connenction->update(
+                    $connection->update(
                         'tx_contexts_settings',
                         ['enabled' => (int) $enabled],
                         ['uid' => (int) $fieldSettings[$field]],
                         [Connection::PARAM_INT],
                     );
                 } else {
-                    $connenction->insert(
+                    $connection->insert(
                         'tx_contexts_settings',
                         [
                             'context_uid' => $contextId,

--- a/Tests/Unit/Classes/Service/DataHandlerServiceTest.php
+++ b/Tests/Unit/Classes/Service/DataHandlerServiceTest.php
@@ -590,9 +590,12 @@ final class DataHandlerServiceTest extends TestCase
         [$queryBuilder, $result] = $this->createQueryBuilderMockWithResultFalse();
         $connection = $this->createMock(Connection::class);
 
+        // The lookup queries tx_contexts_settings, so the QueryBuilder must be
+        // created for that table (issue #168: was tx_contexts_contexts before).
         $this->connectionPool
+            ->expects(self::once())
             ->method('getQueryBuilderForTable')
-            ->with('tx_contexts_contexts')
+            ->with('tx_contexts_settings')
             ->willReturn($queryBuilder);
 
         $this->connectionPool
@@ -846,7 +849,7 @@ final class DataHandlerServiceTest extends TestCase
 
         $this->connectionPool
             ->method('getQueryBuilderForTable')
-            ->with('tx_contexts_contexts')
+            ->with('tx_contexts_settings')
             ->willReturn($queryBuilder);
 
         $this->connectionPool


### PR DESCRIPTION
Two pre-existing findings from the Copilot review of #167, deliberately kept out of that mechanical rector PR — see the issue for details.

`saveRecordSettings()` created its QueryBuilder via `getQueryBuilderForTable('tx_contexts_contexts')` although the query runs against `tx_contexts_settings`. With both tables on the default connection this worked by accident, but it selects the wrong connection as soon as the tables are ever mapped to separate connections, and it misleads the reader. The builder is now created for the table actually queried. Additionally the misspelled local variable `$connenction` (three usages in `saveDefaultSettings()`) is renamed to `$connection` — a pure rename with no behavior change.

Test coverage: the existing unit tests already exercise both paths; the two `getQueryBuilderForTable()` mock constraints in `DataHandlerServiceTest` are updated from the wrong table to `tx_contexts_settings` (one strengthened with `expects(self::once())`), so they now act as the regression guard. Verified in position: re-injecting the old table name makes the suite fail with 3 failures; with the fix the full unit suite passes (742 tests, 1210 assertions). Local gates all green: php -l, PHP-CS-Fixer dry-run, Rector dry-run (cache cleared), PHPStan level 10, unit suite.

Fixes #168
