### PR TITLE
Stop echoing the admin user name into the E2E login log

### DIFF
--- a/Build/playwright/tests/playwright/helper/login.setup.ts
+++ b/Build/playwright/tests/playwright/helper/login.setup.ts
@@ -113,6 +113,10 @@ setup('authenticate with TYPO3 backend', async ({ page }) => {
     const field = page.locator(selector).first();
     if (await field.isVisible({ timeout: 1000 }).catch(() => false)) {
       passwordField = field;
+      // The value logged is the CSS selector that matched, not a credential —
+      // `passwordSelectors` holds strings like `input[type="password"]`. The
+      // alert comes from the variable name, not from the data.
+      // codeql[js/clear-text-logging]
       console.log(`Found password field with selector: ${selector}`);
       break;
     }
@@ -122,8 +126,10 @@ setup('authenticate with TYPO3 backend', async ({ page }) => {
     throw new Error('Could not find password field');
   }
 
-  // Fill login credentials
-  console.log(`Logging in as: ${config.admin.username}`);
+  // Fill login credentials. The user name is not echoed: it comes from the
+  // environment, it ends up in a public CI log, and knowing which account was
+  // used adds nothing to a failure that the screenshot does not already show.
+  console.log('Logging in as the configured admin user');
   await usernameField.fill(config.admin.username);
   await passwordField.fill(config.admin.password);
 


### PR DESCRIPTION
Closes the two `js/clear-text-logging` alerts (both HIGH) in the Playwright login helper.

## Why they appeared now

They are not new defects. This repository stopped analysing JavaScript when the org template began calling CodeQL with the default `languages: actions` — GitHub disables code-scanning *default setup*, which had been covering `javascript-typescript`, as soon as an advanced configuration uploads its first SARIF. [netresearch/.github#348](https://github.com/netresearch/.github/pull/348) fixed that with `languages: auto`, and these two surfaced within minutes of the analysis being restored.

## The two are not the same finding

**`login.setup.ts:126` — removed the value.**

```ts
console.log(`Logging in as: ${config.admin.username}`);
```

`config.admin.username` comes from the environment and this line lands in a public CI log. It is not a password, but it is half of a credential, and it tells someone reading a failure nothing that `login-error.png` does not already show. The message stays, the value is gone.

**`login.setup.ts:116` — suppressed with the reason stated.**

```ts
console.log(`Found password field with selector: ${selector}`);
```

What is logged is the CSS *selector* that matched — `passwordSelectors` holds strings like `input[type="password"]`. The alert follows the variable name, not the data. The line is genuinely useful when the backend markup changes and the helper has to be re-pointed, so it keeps its log and carries a `codeql[js/clear-text-logging]` suppression with the justification inline rather than being silently rewritten.

## Scope

One file, eight added lines, two removed. No test behaviour changes: the same selector search runs, the same credentials are filled.
