### PR TITLE
docs(agents): sync AGENTS.md files and adopt agent-harness verification

### DIFF
--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# Build/Scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,107 +1,70 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-02-27 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md
 
 **Project:** netresearch/contexts — Multi-channel content visibility for TYPO3
-**Type:** TYPO3 CMS Extension (PHP 8.2+, TYPO3 13.4/14.3)
+**Type:** TYPO3 CMS Extension (PHP 8.2–8.5, TYPO3 13.4/14.3; version: see `ext_emconf.php`)
 
 ## Overview
 
-The Contexts extension provides multi-channel content visibility for TYPO3 CMS. It allows content editors to control which content elements, pages, and records are displayed based on configurable context conditions such as:
-
-- Domain/hostname matching
-- IP address ranges
-- GET/POST parameters
-- Cookies
-- HTTP headers
-- Session values
-- Logical combinations (AND/OR/NOT)
-
-Context types are extensible - developers can create custom context implementations by extending `AbstractContext`.
+The Contexts extension lets editors control which content elements, pages, and records are displayed based on configurable context conditions: domain/hostname, IP address ranges, GET/POST parameters, HTTP headers, session values, and logical combinations (AND/OR/NOT). Context types are extensible — developers create custom types by extending `AbstractContext` (see `Classes/AGENTS.md`).
 
 ## Setup / Getting Started
 
 ```bash
-# DDEV setup (recommended)
-cd main && composer install
+composer install
 ddev start
 ddev install-all          # Install TYPO3 v13 and v14
+ddev install-v13          # or a single version
+ddev install-v14
+ddev render-docs          # Render documentation locally
 
-# Or install specific version
-ddev install-v13          # TYPO3 v13 only
-ddev install-v14          # TYPO3 v14 only
-
-# Render documentation locally
-ddev render-docs
-
-# Access
+# Access (credentials: admin / joh316)
 https://v13.contexts.ddev.site/typo3/    # TYPO3 v13 backend
 https://v14.contexts.ddev.site/typo3/    # TYPO3 v14 backend
 https://docs.contexts.ddev.site/         # Local documentation
-
-# Credentials: admin / joh316
 ```
 
 ## Commands
 
 ```bash
-# Pre-commit checks (automatic via CaptainHook)
-composer ci:test:php:cgl      # PHP-CS-Fixer (PSR-12 + strict types)
+# Pre-commit checks (run automatically via CaptainHook)
+composer ci:test:php:cgl      # PHP-CS-Fixer check (PSR-12 + strict types)
 composer ci:test:php:phpstan  # PHPStan level 10
 
 # Testing
 composer ci:test:php:unit        # PHPUnit unit tests
 composer ci:test:php:functional  # PHPUnit functional tests (needs DB)
 composer test:coverage           # Coverage report (needs PCOV/Xdebug)
+composer test:mutation           # Infection mutation testing
+composer test:fuzz               # Fuzz-testing instructions
 
-# Fix commands (for local development)
+# Fix commands
 composer ci:cgl               # Fix code style
 composer ci:rector:fix        # Apply Rector fixes
+
+make help                     # Makefile wrappers: up, ci, test, docs, clean, ...
 ```
 
 ## Development
 
-### Development Workflow
-
-1. **Create feature branch** from `main`
-2. **Make changes** following conventions in this file
-3. **Run local checks** before committing:
-   ```bash
-   composer ci:cgl                # Fix code style
-   composer ci:test:php:phpstan   # Static analysis
-   composer ci:test:php:unit      # Unit tests
-   ```
-4. **Commit** using conventional commits format
-5. **Push** and create PR - CI will run full test suite
-
-### PHPUnit Configuration
-
-PHPUnit configs are located in `Build/phpunit/`:
-- `Build/UnitTests.xml` -> `Build/phpunit/UnitTests.xml`
-- `Build/FunctionalTests.xml` -> `Build/phpunit/FunctionalTests.xml`
-
-Run tests directly via:
-```bash
-./vendor/bin/phpunit -c Build/UnitTests.xml
-./vendor/bin/phpunit -c Build/FunctionalTests.xml
-```
+Workflow: branch from `main`, run `composer ci:cgl`, `ci:test:php:phpstan`, and `ci:test:php:unit` before committing, use Conventional Commits, push and open a PR — CI runs the full matrix.
 
 ### Code Quality Tools
 
 | Tool | Config | Purpose |
 |------|--------|---------|
-| PHP-CS-Fixer | `.php-cs-fixer.dist.php` | Code style (PSR-12) |
+| PHP-CS-Fixer | `Build/php-cs-fixer.php` | Code style (PSR-12) |
 | PHPStan | `Build/phpstan.neon` | Static analysis (level 10) |
 | PHPUnit | `Build/phpunit/*.xml` | Unit & functional tests |
-| CaptainHook | `Build/captainhook.json` | Git hooks (pre-commit, commit-msg) |
-| Rector | `rector.php` | Automated refactoring |
+| CaptainHook | `Build/captainhook.json` | Git hooks (installed via `captainhook/hook-installer`) |
+| Rector | `Build/rector.php` | Automated refactoring |
 | Fractor | `fractor.php` | TYPO3-specific migrations |
 
 ### Extension Best Practices
 
-- **No composer.lock**: Extensions should not commit `composer.lock` (it is gitignored)
-- **Environment files**: `.env` files are gitignored for security
-- **Flat columns**: Use `tx_contexts_enable`/`tx_contexts_disable` for context visibility
+- **No composer.lock**: not committed (gitignored), per TYPO3 extension convention
+- **Flat columns**: `tx_contexts_enable`/`tx_contexts_disable` drive context visibility
 
 ## Critical Constraints
 
@@ -109,121 +72,55 @@ Run tests directly via:
 - **Conventional Commits**: `type(scope): subject`
 - **Ask before**: heavy dependencies, architecture changes, new context types
 - **Never commit** secrets, credentials, or PII
-- **CaptainHook** runs pre-commit checks automatically
 - **Database queries**: Always use `Connection::PARAM_*` (not `PDO::PARAM_*`)
 - **Testing**: Functional tests need database credentials (auto-detected in DDEV)
 
 ## Precedence
 
-The **closest AGENTS.md** to changed files wins. This root file holds global defaults only.
+The **closest AGENTS.md** to changed files wins. This root file holds global defaults only. User prompts override files.
 
-## Index of Scoped AGENTS.md
+## Index of scoped AGENTS.md
 
 | Path | Purpose |
 |------|---------|
-| `Classes/AGENTS.md` | PHP backend code, context types, services |
-| `Configuration/AGENTS.md` | TCA, FlexForms, Services.yaml, Site Sets |
-| `Tests/AGENTS.md` | Testing patterns, fixtures, functional test setup |
-| `Documentation/AGENTS.md` | RST documentation standards |
+| [Classes/AGENTS.md](./Classes/AGENTS.md) | PHP backend code, context types, services |
+| [Configuration/AGENTS.md](./Configuration/AGENTS.md) | TCA, FlexForms, Services.yaml, Site Sets |
+| [Tests/AGENTS.md](./Tests/AGENTS.md) | Testing patterns, fixtures, functional test setup |
+| [Documentation/AGENTS.md](./Documentation/AGENTS.md) | RST documentation standards |
 
 ## Project Structure
 
 ```
-Classes/           # PHP source code (34 files)
-├── Context/       # Context type implementations
-├── Service/       # Business logic services
-└── Form/          # Backend form elements
-Tests/             # Test suite
-├── Unit/          # Unit tests
-├── Functional/    # Functional tests (needs TYPO3)
-├── Architecture/  # PHPat layer tests
-└── Fuzz/          # Property-based fuzz testing
-Configuration/     # TYPO3 configuration (TCA, TypoScript, FlexForms)
+Classes/           # PHP source (Api, Context/Type, Service, Form, Middleware,
+                   #   EventListener, ExpressionLanguage, Query, ViewHelpers, Xclass)
+Tests/             # Unit/, Functional/, Architecture/ (PHPat), Fuzz/
+Configuration/     # TCA, FlexForms, Services.yaml, Sets/ (Site Sets)
 Documentation/     # RST documentation for docs.typo3.org
-Build/             # Build tooling configs (phpstan, phpunit, phpcs)
+Build/             # Tooling configs (phpstan, phpunit, rector, captainhook, Scripts/)
 Resources/         # Frontend assets, language files
+docs/              # Agent-facing docs: ARCHITECTURE.md, plans/, exec-plans/
 ```
+
+Component map and dependency rules: see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## CI Workflows
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `ci.yml` | push/PR | Full test suite (unit, functional, lint, phpstan) |
-| `codeql.yml` | push/PR/schedule | CodeQL security analysis |
-| `dependency-review.yml` | PR | Dependency vulnerability & license review |
-| `docs.yml` | push/PR (Documentation/**) | Render RST documentation |
-| `greetings.yml` | issue/PR opened | Welcome first-time contributors |
-| `labeler.yml` | PR | Auto-label PRs by changed files |
-| `license-check.yml` | push/PR/schedule | PHP dependency license audit |
-| `lock.yml` | schedule | Lock resolved threads after 365 days |
-| `pr-quality.yml` | PR | PR size check + solo-maintainer auto-approve |
-| `publish-to-ter.yml` | release | Publish to TYPO3 Extension Repository |
-| `release.yml` | tag v* | Create signed release with SBOM + cosign |
-| `scorecard.yml` | push/schedule | OpenSSF Scorecard security scan |
-| `security.yml` | push/PR/schedule | Gitleaks + composer audit |
-| `stale.yml` | schedule | Close stale issues/PRs after 60 days |
-| `auto-merge-deps.yml` | PR | Auto-merge Renovate dependency updates |
+| Workflow | Purpose |
+|----------|---------|
+| `ci.yml` | Test matrix via reusable `netresearch/typo3-ci-workflows` (PHP 8.2–8.5 × TYPO3 ^13.4/^14.3, MySQL functional tests, coverage upload) |
+| `checks.yml` | Consolidated security/quality gate (gitleaks, zizmor, fuzz, license check, CodeQL, Scorecard, dependency review, PR quality) |
+| `harness-verify.yml` | Agent-harness consistency (AGENTS.md budget, references, docs/ structure) |
+| `docs.yml` | Render RST documentation |
+| `release.yml` | Signed release with SBOM + cosign on tag `v*` |
+| `publish-to-ter.yml` | Publish to TYPO3 Extension Repository on release |
+
+Full list in `.github/workflows/` (labeler, community, template drift, republish, auto-merge-deps, and standalone security workflows).
 
 ## Key Conventions
 
-### Context Types
-
-New context types extend `AbstractContext` and implement:
-- `match()`: Determine if context is active
-- Configuration via FlexForms in `Configuration/FlexForms/`
-
-```php
-// Context type implementation pattern
-class MyContext extends AbstractContext
-{
-    public function match(array $arDependencies = []): bool
-    {
-        // 1. Check session cache first (if use_session enabled)
-        [$fromSession, $result] = $this->getMatchFromSession();
-        if ($fromSession) {
-            return $result;
-        }
-
-        // 2. Implement matching logic
-        $configValue = $this->getConfValue('field_name');
-        $matches = /* your logic here */;
-
-        // 3. Apply inversion and store in session
-        return $this->storeInSession($this->invert($matches));
-    }
-}
-```
-
-### PSR-14 Event Listeners
-
-```php
-// Use PHP 8 attributes for event listener registration
-#[AsEventListener(
-    identifier: 'contexts/my-listener',
-    event: AfterPageAndLanguageIsResolvedEvent::class,
-)]
-final readonly class MyEventListener
-{
-    public function __invoke(AfterPageAndLanguageIsResolvedEvent $event): void
-    {
-        // Handle event
-    }
-}
-```
-
-### Query Restrictions
-
-Context-based query restrictions filter records automatically:
-
-```php
-// ContextRestriction implements EnforceableQueryRestrictionInterface
-// Applied automatically to pages, tt_content via flat columns
-// Flat columns: tx_contexts_enable, tx_contexts_disable
-```
-
-## When Instructions Conflict
-
-Nearest AGENTS.md wins. User prompts override files.
+- New context types extend `AbstractContext`, implement `match()`, and are configured via FlexForms in `Configuration/FlexForms/ContextType/` — full pattern in [Classes/AGENTS.md](Classes/AGENTS.md)
+- PSR-14 event listeners use the `#[AsEventListener]` attribute (no manual registration)
+- `ContextRestriction` (implements `EnforceableQueryRestrictionInterface`) filters `pages`/`tt_content` automatically via the flat columns
 
 ## Resources
 
@@ -233,4 +130,4 @@ Nearest AGENTS.md wins. User prompts override files.
 
 ## Commit Signing
 
-Signed commits are required: `git commit -S --signoff`. The `require-signed-commits` ruleset on the default branch rejects unsigned commits at merge time, and the DCO check additionally requires the `Signed-off-by` trailer. Quickest setup is SSH signing — register your SSH key as a *signing key* on your GitHub account, then `git config --global gpg.format ssh && git config --global user.signingkey ~/.ssh/<key>.pub`.
+Signed commits are required: `git commit -S --signoff`. The `require-signed-commits` ruleset rejects unsigned commits at merge time; the DCO check additionally requires the `Signed-off-by` trailer. Quickest setup is SSH signing: register your SSH key as a *signing key* on GitHub, then `git config --global gpg.format ssh && git config --global user.signingkey ~/.ssh/<key>.pub`.

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the TYPO3 Contexts extension!
 
 1. Clone the repository
 2. Install dependencies: `composer install`
-3. Run tests: `composer test`
+3. Run tests: `composer ci:test:php:unit` (or `make test` inside DDEV)
 
 ## Code Quality
 

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Classes/
 
@@ -7,6 +7,7 @@ Backend PHP code for the Contexts extension.
 ## Overview
 
 This directory contains the core PHP implementation:
+- **Api/**: Public extension API (`Configuration`, `ContextMatcher`, `Record`)
 - **Context/**: Context type implementations (GetParam, Domain, IP, etc.)
 - **Context/Type/**: Concrete context type classes extending AbstractContext
 - **Service/**: Business logic (matching, data handling)
@@ -16,6 +17,7 @@ This directory contains the core PHP implementation:
 - **Query/Restriction/**: Doctrine DBAL query restrictions for context-based filtering
 - **ExpressionLanguage/**: Symfony ExpressionLanguage providers for TypoScript conditions
 - **ViewHelpers/**: Fluid ViewHelpers for context-aware rendering
+- **Xclass/**: Core class extensions (backend page tree repository)
 
 ## Setup & Environment
 
@@ -28,7 +30,7 @@ ddev start && ddev install-v13
 
 ```bash
 composer ci:test:php:cgl      # PHP-CS-Fixer
-composer ci:test:php:phpstan  # PHPStan level 9
+composer ci:test:php:phpstan  # PHPStan level 10
 composer ci:test:php:unit     # Unit tests for this code
 ```
 

--- a/Classes/CLAUDE.md
+++ b/Classes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Configuration/AGENTS.md
+++ b/Configuration/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md - Configuration/
 
@@ -32,6 +32,10 @@ Configuration/
 ├── RequestMiddlewares.php # PSR-15 middleware config
 └── ExpressionLanguage.php # Symfony ExpressionLanguage providers
 ```
+
+## Setup
+
+Configuration files here are loaded by TYPO3 at bootstrap — there is no separate build step. Test changes against the DDEV instances (`ddev start`, `ddev install-v13` / `ddev install-v14`, backend at `https://v13.contexts.ddev.site/typo3/`). TCA, FlexForm, and Services.yaml changes only take effect after a cache flush (see below).
 
 ## Build & Tests
 

--- a/Configuration/CLAUDE.md
+++ b/Configuration/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Documentation/
 
@@ -22,8 +22,8 @@ Documentation/
 ## Setup & Environment
 
 ```bash
-# Render locally with DDEV
-ddev docs
+# Render locally with DDEV (or: make docs)
+ddev render-docs
 
 # Or with Docker directly
 docker run --rm \
@@ -39,7 +39,7 @@ open Documentation-GENERATED-temp/Index.html
 
 ```bash
 # Validate RST syntax
-ddev docs  # Warnings shown during render
+ddev render-docs  # Warnings shown during render
 
 # Check output directory (TYPO3 convention)
 ls Documentation-GENERATED-temp/
@@ -131,7 +131,7 @@ Query Parameter Context
 
 ## PR/Commit Checklist
 
-- [ ] RST renders without warnings: `ddev docs`
+- [ ] RST renders without warnings: `ddev render-docs`
 - [ ] Cross-references resolve (no broken `:ref:` links)
 - [ ] Code examples have language specified
 - [ ] Sentence case headings

--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- Regular file, not a symlink: the TYPO3 docs renderer (Flysystem) rejects symbolic links inside Documentation/. -->
+
+@AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-01-28 -->
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Tests/
 
@@ -35,8 +35,8 @@ export typo3DatabasePassword=root
 ## Build & Tests
 
 ```bash
-# Run all tests
-composer test
+# Run all tests (unit + functional)
+make test
 
 # Run specific suites
 composer ci:test:php:unit           # Unit tests only (~fast)
@@ -91,7 +91,7 @@ self::assertInstanceOf(Context::class, $object);
 ## PR/Commit Checklist
 
 - [ ] New functionality has corresponding tests
-- [ ] All tests pass: `composer test`
+- [ ] All tests pass: `make test`
 - [ ] No skipped tests without justification
 - [ ] Fixtures use `use_session=0` for session-based features
 

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,45 @@
+# Architecture
+
+Agent-facing component map for the Contexts extension. For usage documentation see `Documentation/` (rendered at docs.typo3.org).
+
+## System Overview
+
+Contexts is a TYPO3 extension that evaluates configurable conditions ("contexts") per request and uses the result to control record visibility. A PSR-15 middleware initializes the context container early in the frontend request; matched contexts then drive query restrictions (flat columns `tx_contexts_enable`/`tx_contexts_disable` on `pages` and `tt_content`), page access checks, menu filtering, cache segmentation, and TypoScript conditions.
+
+## Components
+
+| Component | Path | Responsibility |
+|-----------|------|----------------|
+| Public API | `Classes/Api/` | `Configuration` (context type registry), `ContextMatcher` (`matches('alias')` for TypoScript/code), `Record` (record-level enable/disable checks) |
+| Context base | `Classes/Context/AbstractContext.php` | Base class for all context types: FlexForm config access, inversion, session caching, PSR-7 request access |
+| Context container | `Classes/Context/Container.php` | Singleton holding all matched contexts for the current request; dependency-ordered evaluation |
+| Context factory | `Classes/Context/Factory.php` | Instantiates context objects from `tx_contexts_contexts` rows |
+| Context types | `Classes/Context/Type/` | `DomainContext`, `IpContext`, `QueryParameterContext`, `HttpHeaderContext`, `SessionContext`, `CombinationContext` (+ `Combination/LogicalExpressionEvaluator` for AND/OR/NOT expressions) |
+| Middleware | `Classes/Middleware/ContainerInitialization.php` | PSR-15 middleware (registered in `Configuration/RequestMiddlewares.php`) that initializes the container with the frontend request |
+| Event listeners | `Classes/EventListener/` | PSR-14 listeners: FlexForm data structure resolution, icon overlay, menu item filtering, page access, page cache identifier, TypoScript config |
+| Services | `Classes/Service/` | `DataHandlerService` (flat column sync on save), `FrontendControllerService`, `PageService`, `QueryParameterService`, `IconService`, `InstallService` |
+| Query restriction | `Classes/Query/Restriction/ContextRestriction.php` | `EnforceableQueryRestrictionInterface` implementation filtering records by matched contexts |
+| Expression language | `Classes/ExpressionLanguage/` | `contextMatch()` TypoScript condition function (registered via `Configuration/ExpressionLanguage.php`) |
+| ViewHelpers | `Classes/ViewHelpers/MatchesViewHelper.php` | `contexts:matches` for Fluid templates |
+| XCLASS | `Classes/Xclass/Backend/Tree/Repository/PageTreeRepository.php` | Backend page tree integration |
+| Configuration | `Configuration/` | TCA (`tx_contexts_contexts` + overrides for `pages`/`tt_content`), FlexForms per context type, `Services.yaml`, Site Set (`Sets/Contexts/`) |
+
+## Dependency Rules
+
+Enforced by PHPat in `Tests/Architecture/LayerTest.php` (runs with the unit test suite):
+
+- Classes in `Netresearch\Contexts\Context\Type` must extend `AbstractContext` (excluding the `LogicalExpressionEvaluator` helper and its exception).
+- Classes in `Netresearch\Contexts\Event` must be final. (Namespace currently has no classes; the rule guards future additions.)
+- Classes in `Netresearch\Contexts\Dto` must be readonly. (Namespace currently has no classes; the rule guards future additions.)
+
+## Data Flow
+
+1. **Editing time**: `DataHandlerService` reacts to record saves and syncs each context's enable/disable settings into the flat columns of `pages`/`tt_content`.
+2. **Request time**: `ContainerInitialization` middleware initializes `Container`, which loads active `tx_contexts_contexts` rows via `Factory` and evaluates `match()` per context (dependency-ordered, session-cached where configured).
+3. **Rendering**: `ContextRestriction` filters queries by the matched context UIDs; event listeners adjust page access, menus, and the page cache identifier; TypoScript conditions and Fluid ViewHelpers query `ContextMatcher`.
+
+## Key Decisions
+
+- Modernization plan and rationale: `docs/plans/2026-02-27-gold-standard-modernization-design.md` and `docs/plans/2026-02-27-gold-standard-modernization.md`
+- v13/v14 upgrade plan: `docs/plans/2026-01-28-contexts-family-upgrade-v13.md`
+- Migration notes for released versions: `Documentation/Migration/Index.rst`

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,8 @@
+# Execution Plans
+
+Working directory for agent execution plans.
+
+- `active/` — plans currently being executed (create on demand)
+- `completed/` — finished plans kept for reference (create on demand)
+
+Long-lived design/modernization plans live in `docs/plans/`. Execution plans here are task-scoped, disposable checklists an agent follows for a single change; keep one file per task, move it to `completed/` when done.


### PR DESCRIPTION
## Description

Syncs all five AGENTS.md files against the verified repo state and adopts agent-harness Level 2/3 verification, as assessed in #180.

**Drift fixed:** phantom commands (`composer test` in Tests/AGENTS.md and CONTRIBUTING.md — the real commands are `composer ci:test:php:unit`/`ci:test:php:functional` or `make test`; `ddev docs` in Documentation/AGENTS.md — actual command is `ddev render-docs`), stale facts (PHPStan level 9 vs actual level 10 in Build/phpstan.neon; tool table pointing at `.php-cs-fixer.dist.php`/`rector.php` while the composer scripts use `Build/php-cs-fixer.php`/`Build/rector.php`; a nonexistent "Cookies" context type; maintainer-local `cd main` setup step; missing `Api/` and `Xclass/` namespaces in the Classes scope overview), and a CI workflow table predating the checks.yml consolidation.

**Structure added:** CLAUDE.md companions next to every scoped AGENTS.md (symlinks; a regular `@AGENTS.md` import file in Documentation/ because the TYPO3 docs renderer rejects symlinks inside Documentation/), a scope index with working links, the missing Setup section in Configuration/AGENTS.md, docs/ARCHITECTURE.md (component map plus the PHPat dependency rules from Tests/Architecture/LayerTest.php), docs/exec-plans/README.md, and Build/Scripts/verify-harness.sh with a thin harness-verify.yml caller of the shared script-check reusable. The root AGENTS.md went from 236 to 133 lines (harness budget is under 150); curated content (context type patterns, security notes, house rules) was preserved and only facts were corrected.

## Related Issue

Fixes #180

## Type of Change

- [x] Documentation update

## Testing

Before/after on this branch: agent-rules quality score 71/100 -> 93/100 (average over 5 files), validate-structure 5 errors / 1 warning -> 0 / 0, verify-content 0 warnings before and after, agent-harness "Level 1 PARTIAL, 3 errors / 2 warnings" -> "Level 2 PARTIAL, 0 errors / 1 warning". The remaining harness warning ("no git hooks auto-setup detected") is a heuristic false negative: hooks are auto-installed by the `captainhook/hook-installer` composer plugin (pulled in via `netresearch/typo3-ci-workflows`) with `extra.captainhook.config`, which the script's .envrc/.husky/post-install-cmd heuristic does not recognize.

- [x] Unit tests pass (`composer ci:test:php:unit`)
- [ ] Functional tests pass (`composer ci:test:php:functional`) — not run locally (needs DB); covered by CI
- [x] Static analysis passes (`composer ci:test:php:phpstan`)
- [x] Code style passes (`composer ci:test:php:cgl`)

Unit tests, PHPStan, and CGL ran via the CaptainHook pre-commit hook on this commit.

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have added/updated tests for my changes — documentation-only change
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (if applicable) — not applicable, agent-facing docs only