### PR TITLE
docs: document activation routes that work

### DIFF
--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -6,135 +6,15 @@
 Changelog
 =========
 
-All notable changes to this project are documented here.
+The changelog is maintained in the repository and published with each release.
+It is not duplicated here, because a second copy is a second thing to forget:
+this page stopped at version 5.0.0 while the repository had already shipped
+5.0.1 and 5.0.2.
 
-Version 5.0.0
-=============
+`CHANGELOG.md <https://github.com/netresearch/t3x-contexts/blob/main/CHANGELOG.md>`__
+   Every release, newest first.
 
-This is a major release targeting TYPO3 v13.4 LTS and v14.3 LTS. It also fixes
-several defects, two of which were already silent on TYPO3 v13.
+`Releases <https://github.com/netresearch/t3x-contexts/releases>`__
+   The same entries per version, with the tag and the assets.
 
-Breaking Changes
-----------------
-
-- **Dropped TYPO3 v12.4 support** - use version 4.x for TYPO3 v12.4
-- **Removed** :file:`ext_tables.php` - deprecated in TYPO3 v14.3
-  (:issue:`109438`)
-- **Removed** ``FrontendControllerService::registerQueryParameter()``,
-  ``::createHashBase()`` and ``::configArrayPostProc()``
-- **Removed** ``PageService::createHashBase()`` - use the public
-  ``PageService::getHashString()``
-- **Removed** the empty ``CacheHashEventListener``
-- **Removed** the protected ``AbstractContext::getTypoScriptFrontendController()``
-  and ``AbstractContext::getIndpEnv()`` - custom context types use
-  ``getRequest()``, ``getFrontendUser()`` and ``getNormalizedParams()``
-- **Dropped** the unused ``typo3/cms-extbase`` and ``typo3/cms-extensionmanager``
-  requirements - no class of either package is referenced
-- **Removed** the site set settings ``contexts.matchMode`` and
-  ``contexts.cacheLifetimeModifier`` - neither was ever read by the extension
-- :php:`Configuration::registerContextType()` **no longer writes** the FlexForm
-  file into ``TCA[tx_contexts_contexts][columns][type_conf][config][ds]``; the
-  data structure is resolved from the context type registry instead
-
-Bug Fixes
----------
-
-- **Context records can be edited on TYPO3 v14.3 again** - ``ds_pointerField``
-  and the multi-entry ``ds`` array were removed in TYPO3 v14.0
-  (:issue:`107047`), so every read of ``tx_contexts_contexts.type_conf`` threw
-  an ``InvalidTcaException``. ``FlexFormDataStructureEventListener`` resolves
-  the data structure through the PSR-14 ``BeforeFlexFormDataStructure*`` events,
-  which behave identically on v13.4 and v14.3
-- **Frontend caches are invalidated when a context record changes** - saving,
-  deleting or restoring a context flushes the ``pages`` cache group. TYPO3
-  caches the :php:`ModifyTypoScriptConfigEvent` result under an identifier
-  derived from the TypoScript sources, so a new or renamed GET parameter
-  context previously never reached :typoscript:`config.linkVars`
-
-- **Session context matches again** - the frontend user is read from the
-  ``frontend.user`` request attribute instead of the ``TypoScriptFrontendController``
-  removed in TYPO3 v14 (:issue:`107831`). The same applies to the
-  ``use_session`` persistence of the GET parameter context
-- **Context-aware page caching works again** - the active contexts and the
-  values of all context GET parameters are added to the page cache identifier
-  via :php:`\TYPO3\CMS\Frontend\Event\BeforePageCacheIdentifierIsHashedEvent`,
-  replacing the ``createHashBase`` hook removed in TYPO3 v13.0
-  (:issue:`102932`)
-- **config.linkVars works again** - the GET parameters of all query parameter
-  contexts are appended via
-  :php:`\TYPO3\CMS\Frontend\Event\ModifyTypoScriptConfigEvent`, replacing the
-  removed ``configArrayPostProc`` hook
-- **Page tree restrictions are no longer dropped** - the ``PageTreeRepository``
-  XCLASS forwards the third ``$additionalQueryRestrictions`` constructor
-  argument, so ``options.pageTree.excludeDoktypes`` is honoured again
-- **Removed** the write to ``$TYPO3_CONF_VARS['FE']['addRootLineFields']``,
-  removed in TYPO3 v13.2 (:issue:`103752`)
-
-Improvements
-------------
-
-- CI matrix covers TYPO3 ``^13.4`` and ``^14.3`` on PHP 8.2 - 8.5
-- :file:`composer.json` declares ``extra.typo3/cms.version`` and
-  ``extra.typo3/cms.Package.providesPackages`` (:issue:`108345`)
-- Rector and Fractor run the TYPO3 v14 rule sets; the one rule that may not be
-  applied while TYPO3 v13.4 is supported is skipped explicitly
-- PHPStan enables ``reportUnmatchedIgnoredErrors`` and drops the 27 ignore
-  patterns that no longer matched anything
-- DDEV development environment provides TYPO3 v13 and v14 instances
-
-Version 4.0.0
-=============
-
-Release date: 2026-03-01
-
-This is a major release with TYPO3 v12/v13 support and significant modernization.
-
-Breaking Changes
-----------------
-
-- **Dropped TYPO3 v11 support** - Use version 3.x for TYPO3 v11
-- **Dropped PHP 7.4/8.0/8.1 support** - Minimum PHP 8.2 required
-- **Removed SC_OPTIONS hooks** - Migrated to PSR-14 events
-- **PHPUnit 10/11/12/13 required** - Test code must use new patterns
-
-New Features
-------------
-
-- **TYPO3 v12.4 LTS support** - Full compatibility with TYPO3 v12
-- **TYPO3 v13.4 LTS support** - Full compatibility with TYPO3 v13
-- **Site Sets support** - Modern site configuration for TYPO3 v13
-- **PHP 8.2/8.3/8.4/8.5 support** - Latest PHP versions supported
-- **PSR-14 events** - Modern event dispatching system
-- **PHP 8 Attributes** - Native attribute-based configuration
-- **Docker-based runTests.sh** - TYPO3 core testing pattern
-
-Improvements
-------------
-
-- Modernized codebase with strict types
-- Enhanced IDE support through better typing
-- Improved test coverage (target: 80%+)
-- **Mutation testing** - Infection with MSI > 80%
-- PHPStan level 10 compliance
-- Updated coding standards (PSR-12)
-
-Migration
----------
-
-See :ref:`migration` for detailed upgrade instructions.
-
-Version 3.x
-===========
-
-Legacy version supporting TYPO3 v10 and v11. No longer actively developed.
-Use version 4.0+ for new installations.
-
-Version 2.x
-===========
-
-Legacy version supporting TYPO3 v8 and v9. End of life.
-
-Version 1.x
-===========
-
-Initial release for TYPO3 v6 and v7. End of life.
+Upgrading from an older major version is described in :ref:`migration`.

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -15,8 +15,8 @@ in your site configuration. Add the contexts Site Set to your site:
 .. code-block:: yaml
    :caption: config/sites/<identifier>/config.yaml
 
-   imports:
-     - { resource: "EXT:contexts/Configuration/Sets/Contexts/config.yaml" }
+   dependencies:
+     - netresearch/contexts
 
    settings:
      contexts:

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -56,20 +56,8 @@ Alternatively, add it to your site's :file:`config/sites/<identifier>/config.yam
 
 .. code-block:: yaml
 
-   imports:
-     - { resource: "EXT:contexts/Configuration/Sets/Contexts/config.yaml" }
-
-.. _installation-classic:
-
-Classic TypoScript Include (TYPO3 v13+)
-=======================================
-
-For traditional TypoScript setup, include the static template:
-
-1. Go to :guilabel:`Web > Template`
-2. Select your root page
-3. Edit the template record
-4. In :guilabel:`Includes`, add "Contexts" to the selected items
+   dependencies:
+     - netresearch/contexts
 
 .. _installation-database:
 

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -273,8 +273,8 @@ Migration Steps
 
    .. code-block:: yaml
 
-      imports:
-        - { resource: "EXT:contexts/Configuration/Sets/Contexts/config.yaml" }
+      dependencies:
+        - netresearch/contexts
 
 2. Configure settings in your site configuration:
 


### PR DESCRIPTION
Closes #184, closes #185, closes #186. Three defects on one subject — how a reader turns the extension on — so they are fixed in one pass. Each premise was re-checked against the code before changing anything.

## Site set activation used a key that does not activate anything (#184)

All three places showing how to activate the set used `imports:`. Core reads active sets from `dependencies`:

```php
// vendor/typo3/cms-core/Classes/Site/Entity/Site.php:136
$this->sets = $configuration['dependencies'] ?? [];
```

A site following the documentation therefore loaded the set's YAML as plain data and never activated it — no TypoScript from `setup.typoscript`, `contexts.debug` without effect, and nothing errors, because `imports:` is a valid YAML-loader feature. The set's own name is `netresearch/contexts` (`Configuration/Sets/Contexts/config.yaml`), and `Tests/Functional/SiteSetTypoScriptTest.php` already activates it the working way — the covered path and the documented path had drifted apart.

Fixed in `Documentation/Installation/Index.rst`, `Documentation/Configuration/Index.rst` and `Documentation/Migration/Index.rst`.

## The static template does not exist (#186)

`Documentation/Installation/Index.rst` described a "Classic TypoScript Include" and told readers to add "Contexts" in the template record's `Includes` list. No `addStaticFile()` call exists anywhere in the extension, and there is no `Configuration/TypoScript/` directory — the only TypoScript outside `Tests/` is delivered through the site set.

Removed rather than implemented: registering a static template is a feature decision, and the page already documents the site set route directly above. Nothing referenced the section's label (`installation-classic`), so no cross-reference breaks.

## The changelog page claimed completeness and stopped two releases back (#185)

The page stated "All notable changes to this project are documented here" and ended at 5.0.0, while `CHANGELOG.md` was at 5.0.2. It duplicated 140 lines of a file that every release updates anyway.

#185 offered two ways out. This takes the second — one source instead of two — because the first costs a duplicated edit per release and had already drifted twice. The page stays in the toctree so navigation is unaffected, and points at `CHANGELOG.md` and the releases list.

## Verification

`render-guides` renders all 9 documents without an error or warning, and the two links on the rewritten page resolve in the generated HTML.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
