### PR TITLE
fix: apply Rector finding for rector/rector 2.6.6

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,7 +149,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -34,9 +34,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Backend\Tree\Repository\
 ];
 
 // Contexts query restriction - applied to all database queries
-if (!isset($GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions'][ContextRestriction::class])) {
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions'][ContextRestriction::class] = [];
-}
+$GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions'][ContextRestriction::class] ??= [];
 
 // Register custom form elements for TCA
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1700000001] = [


### PR DESCRIPTION
Two fixes for `main`, both required to get this repo green.

## Rector

The `ci / Rector` job fails on `main` ([run 34089622292](https://github.com/netresearch/t3x-contexts/actions/runs/34089622292)). `IfToNullCoalescingAssignRector` collapses the `isset` guard around the `additionalQueryRestrictions` entry in `ext_localconf.php` into `??=`. Rector 2.6.6 added the rule to the configured set.

The extension carries no `composer.lock` by convention, so CI resolves Rector fresh on every run and picked up the new rule the moment 2.6.6 was released. Applying it is the fix — no rule was skipped in `Build/rector.php`.

## Template drift

`.github/workflows/checks.yml` still pinned `step-security/harden-runner` at `05e31511` (v2.21.0) while the `typo3-extension` template moved to `e14015d5` (v2.21.1). That one line is the whole of netresearch/.github#403, and it fails the required `drift / Template drift` check on every branch cut from `main`, including this one — so the Rector fix cannot merge without it.

After the change the file is byte-identical to the template-synced copy in `netresearch/t3x-nr-xliff-streaming`, verified with `diff`. This supersedes the duplicate bot PRs #190 and #191.

## Tests

On PHP 8.5.10, all exit 0: php-cs-fixer dry-run, PHPStan, Rector dry-run, the unit suite, and 129 functional tests (7 skipped). The functional suite ran locally on SQLite; CI runs it on MySQL. The previous push of this branch already showed `ci / Rector` green in CI.

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Gcm3GRuYBxJGtyj7qviJF8)_
